### PR TITLE
Clean up warnings.

### DIFF
--- a/src/log-local.cpp
+++ b/src/log-local.cpp
@@ -25,7 +25,7 @@ void LogLocalHandler::log(String message, LogLevel level) {
         {
             logFile.position = 0;
         }
-        logFile.log[logFile.position] = (uint8_t)message[i];
+        logFile.log[logFile.position] = (uint8_t)message.charAt(i);
     }
     if (++logFile.position >= logFile.size)
     {


### PR DESCRIPTION
Retested this and logs uploaded to device/logs on particle.  Log statements also sent to serial output for debug build.